### PR TITLE
🚑️ Fix: 자유게시판 404 에러 해결

### DIFF
--- a/src/pages/board/[boardId].tsx
+++ b/src/pages/board/[boardId].tsx
@@ -1,0 +1,10 @@
+import { useRouter } from 'next/router';
+
+const BoardDetail = () => {
+  const router = useRouter();
+  const { boardId } = router.query;
+
+  return <div>{boardId}번 게시물</div>;
+};
+
+export default BoardDetail;


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->

- close #55 

## ✅ 작업 사항

<!-- 작업한 내용에 대해 작성해주세요. -->

### 발생한 문제

배포한 곳, 빌드 후 실행을 하니 아래와 같이 이런 에러를 발견했습니다.

<img width="956" alt="image" src="https://github.com/wiki-viki/wiki-viki/assets/98106371/cdcf6d4c-3b33-4755-a142-4e3976069b7c">

### 문제 발생한 이유

알고보니깐 이게 문제였습니다.. `/board/${board.id}` 이 페이지를 미리 준비해야되는데 해당 페이지가 없어 404 에러가 떴던 거였습니다....

```jsx
<Link href={`/board/${board.id}`} rel="preload">
```

### 해결

그래서 해당 페이지를 만들고 다시 빌드하고 실행하니깐 오류가 안뜨더라구요.
push 하시기 전에 `npm run build` -> `npm run start` 해서 테스트해봐야될 거 같네요 🤣


## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

<img width="1011" alt="image" src="https://github.com/wiki-viki/wiki-viki/assets/98106371/e2abc2e9-3c69-4f2d-84aa-0d7cd17f7c42">


## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
